### PR TITLE
Fix setting of environment variable when no value present

### DIFF
--- a/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
@@ -1,11 +1,11 @@
 function AppendToEnvironmentVariable($name, $appendValue)
 {
-    $value = [Environment]::GetEnvironmentVariable($name, 'Machine')
+    $value = [Environment]::GetEnvironmentVariable($name)
     if ($value -eq $null) {
-      [Environment]::SetEnvironmentVariable($name, 'StartupDiagnostics', 'Machine')
+      [Environment]::SetEnvironmentVariable($name, $appendValue)
     } else {
       if ($value -notcontains $appendValue) {
-        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue, 'Machine')
+        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue)
       }
     }
 }

--- a/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
@@ -1,11 +1,11 @@
 function AppendToEnvironmentVariable($name, $appendValue)
 {
-    $value = [Environment]::GetEnvironmentVariable($name)
+    $value = [Environment]::GetEnvironmentVariable($name, 'Machine')
     if ($value -eq $null) {
-      [Environment]::SetEnvironmentVariable($name, $appendValue)
+      [Environment]::SetEnvironmentVariable($name, $appendValue, 'Machine')
     } else {
       if ($value -notcontains $appendValue) {
-        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue)
+        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue, 'Machine')
       }
     }
 }


### PR DESCRIPTION
The AppendToEnvironmentVariable function in ./deploy.ps1 incorrectly set DOTNET_ADDITIONAL_DEPS and DOTNET_SHARED_STORE to "StartupDiagnostics" when their value was null. This PR fixes that issue.